### PR TITLE
Fix README and install script to run on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,17 @@ To download and run it, first ensure `uv` is installed (see Prerequisites above)
 
 ```bash
 curl -LO https://raw.githubusercontent.com/intro-stat-learning/ISLP_labs/main/setup_notebook_env.py
-uv run python setup_notebook_env.py --outdir ISLP_v2.2.2 --commit v2.2.2 --python-version 3.12
 ```
 
 ### 2. Run the setup script
 
-Open your terminal and run the following command to set up the environment for version `v2.2.2` of the labs with Python `3.12`. You can also specify one or more notebooks to run automatically after setup.
+Open your terminal and run the following command to set up the environment for version `v2.2.2` of the labs with Python `3.12`.
+
+```
+uv run python setup_notebook_env.py --outdir ISLP_v2.2.2 --commit v2.2.2 --python-version 3.12
+```
+
+You can also specify one or more notebooks to run automatically after setup.
 
 *   `--outdir ISLP_v2.2.2`: This will create a directory named `ISLP_v2.2.2` for your labs.
 *   `--commit v2.2.2`: This specifies that you want to use version `v2.2.2` of the labs.

--- a/setup_notebook_env.py
+++ b/setup_notebook_env.py
@@ -87,10 +87,11 @@ def setup_env(outdir,
         run_command([uv_executable, 'venv', '--python', python_version, '--seed'], cwd=str(outdir))
 
         print("Installing requirements...")
-        venv_dir = Path('.venv')
-        uv_bin = venv_dir / 'Scripts' if sys.platform == 'win32' else venv_dir / 'bin' 
+        venv_dir = outdir / '.venv'
+        uv_bin = venv_dir / 'Scripts' if sys.platform == 'win32' else venv_dir / 'bin'
+        uv_pip = (uv_bin / 'pip').resolve()
         
-        run_command([str(uv_bin / 'pip'), 'install', '-r', 'requirements.txt', 'jupyterlab'], cwd=str(outdir))
+        run_command([str(uv_pip), 'install', '-r', 'requirements.txt', 'jupyterlab'], cwd=str(outdir))
         
         if nbfiles:
             if allow_errors:


### PR DESCRIPTION
1. In the README there was written "Following command" without any command actually following
2. If the executable path is a relative path, it is looked up by `subprocess.Popen` only on POSIX systems, not on Windows. See [the docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)